### PR TITLE
Add explicit chart.js dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   "dependencies": {
     "@folio/stripes-webpack": "^1.2.0",
     "@folio/stripes-acq-components": "^2.4.3",
+    "chart.js": "^3.1.0",
     "lodash": "^4.17.21",
     "randomcolor": "^0.6.2",
     "react-chartjs-2": "^2.11.1"


### PR DESCRIPTION
react-chartjs-2 has this as a dev-dependency only: it's not even
listed as a peer-dependency. I assume some other FOLIO module has been
including it and I have been accidentally benefitting from that, but
we don't want to rely on that.