### PR TITLE
Depend on chart.js 2.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "regenerator-runtime": "^0.13.3"
   },
   "dependencies": {
-    "chart.js": "^3.1.0",
+    "chart.js": "^2.6.0",
     "@folio/stripes-webpack": "^2.0.0",
     "@folio/stripes-acq-components": "^3.0.0",
     "lodash": "^4.17.21",


### PR DESCRIPTION
Rather than chart.js 3.1.0. This fixes error

Error: TypeError: Cannot read properties of undefined (reading 'eventHandler')
at getEventHandler (http://localhost:3000/bundle.js:313884:22)

in my setup.