### PR TITLE
Add permission "plugin-eusage-reports.view-charts"

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,14 @@
       {
         "permissionName": "module.ui-plugin-eusage-reports.enabled",
         "displayName": "UI: eusage-reports plugin is enabled"
+      },
+      {
+        "permissionName": "plugin-eusage-reports.view-charts",
+        "displayName": "eUsage reports: charts may be viewed",
+        "subPermissions": [
+          "module.ui-plugin-eusage-reports.enabled"
+        ],
+        "visible": true
       }
     ]
   },


### PR DESCRIPTION
This permission is currently not checked by anything. We will add the
checking code once the permission exists on the thor server, so it's
actually possible to add it to a user.

Towards UIPER-74.