### PR TITLE
Check permission "eUsage reports: charts may be viewed"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [2.0.1](https://github.com/folio-org/ui-plugin-eusage-reports/tree/v2.0.1) (IN PROGRESS)
 
 * "eUsage reports" accordion in the Agreements app is closed by default. Fixes UIPER-70.
-* New permission, "eUsage reports: charts may be viewed" (`plugin-eusage-reports.view-charts`). Towards UIPER-74.
+* New permission, "eUsage reports: charts may be viewed" (`plugin-eusage-reports.view-charts`), determines whether the "eUsage reports" accordion is visible. Fixes UIPER-74.
 * Send `format` parameter as part of cost-per-use charting requests. Fixes UIPER-79.
 
 ## [2.0.0](https://github.com/folio-org/ui-plugin-eusage-reports/tree/v2.0.0) (2021-10-06)

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
+import { IfPermission } from '@folio/stripes/core';
 import { Accordion } from '@folio/stripes/components';
 import MatchingSummary from './loaders/MatchingSummaryLoader';
 import EusageVisualizationLoader from './loaders/EusageVisualizationLoader';
@@ -40,13 +41,15 @@ const PluginEusageReports = ({ data }) => {
     );
   } else {
     return (
-      <Accordion
-        id="plugin-eusage-reports-charts"
-        label={<FormattedMessage id="ui-plugin-eusage-reports.accordion.label" />}
-        closedByDefault
-      >
-        <EusageVisualizationLoader data={data?.data} />
-      </Accordion>
+      <IfPermission perm="plugin-eusage-reports.view-charts">
+        <Accordion
+          id="plugin-eusage-reports-charts"
+          label={<FormattedMessage id="ui-plugin-eusage-reports.accordion.label" />}
+          closedByDefault
+        >
+          <EusageVisualizationLoader data={data?.data} />
+        </Accordion>
+      </IfPermission>
     );
   }
 };


### PR DESCRIPTION
(`plugin-eusage-reports.view-charts`), determines whether the "eUsage reports" accordion is visible.

Fixes UIPER-74.