### PR TITLE
Add subpermissions to `plugin-eusage-reports.view-charts`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-plugin-eusage-reports
 
+## [2.2.0](https://github.com/folio-org/ui-plugin-eusage-reports/tree/v2.2.0) (IN PROGRESS)
+
+* "eUsage reports: charts may be viewed" (`plugin-eusage-reports.view-charts`) permission now includes all relevant back-end permissions. Fixes the last part of UIPER-74.
+
 ## [2.1.0](https://github.com/folio-org/ui-plugin-eusage-reports/tree/v2.1.0) (2021-10-06)
 
 * "eUsage reports" accordion in the Agreements app is closed by default. Fixes UIPER-70.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,12 @@
         "permissionName": "plugin-eusage-reports.view-charts",
         "displayName": "eUsage reports: charts may be viewed",
         "subPermissions": [
-          "module.ui-plugin-eusage-reports.enabled"
+          "module.ui-plugin-eusage-reports.enabled",
+          "eusage-reports-report-use-over-time.get",
+          "eusage-reports-report-reqs-by-date-of-use.get",
+          "eusage-reports-report-reqs-by-pub-year.get",
+          "eusage-reports-report-cost-per-use.get",
+          "eusage-reports-report-status.get"
         ],
         "visible": true
       }


### PR DESCRIPTION
"eUsage reports: charts may be viewed" (`plugin-eusage-reports.view-charts`)
permission now includes all relevant back-end permissions.

 Fixes the last part of UIPER-74.