### PR TITLE
omit unused @folio/stripes-webpack devdep

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
   },
   "dependencies": {
     "chart.js": "^2.6.0",
-    "@folio/stripes-webpack": "^2.0.0",
     "@folio/stripes-acq-components": "^3.0.0",
     "lodash": "^4.17.21",
     "randomcolor": "^0.6.2",


### PR DESCRIPTION
The `devDependency` on `@folio/stripes-webpack` is unnecessary and
should be removed. The only useful export from that repo, relating to
babel config options, is re-exported via `@folio/stripes-cli` and should
be imported via that repository instead, if necessary.