### PR TITLE
UIPER-109-downloadCSV-mock

### DIFF
--- a/src/util/downloadCSV.test.js
+++ b/src/util/downloadCSV.test.js
@@ -2,6 +2,7 @@ import fetch from 'node-fetch';
 import downloadCSV from './downloadCSV';
 
 window.fetch = fetch;
+jest.unmock('./downloadCSV');
 
 const mockAnchorElement = {
   click: () => undefined,

--- a/test/jest/setupTests.js
+++ b/test/jest/setupTests.js
@@ -1,3 +1,4 @@
 import './__mock__';
 import 'regenerator-runtime/runtime';
 
+jest.mock('../../src/util/downloadCSV', () => jest.fn());


### PR DESCRIPTION
Several tests are triggering the downloadCSV function by clicking a button.
The downloadCSV function then makes actual fetch requests to the provided URLs.
This results in test errors / warnings. See [UIPER-109](https://issues.folio.org/browse/UIPER-109).

To prevent this, i have mocked the downloadCSV implementation in tests to do nothing.