### PR TITLE
UIPER-122 Update plugin-find-eresource dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-plugin-eusage-reports
 
 ## (3.2.0) IN PROGRESS
+* Update plugin-find-eresource dependency [UIPER-122](https://folio-org.atlassian.net/browse/UIPER-122)
 
 ## [3.1.0](https://github.com/folio-org/ui-plugin-eusage-reports/tree/v3.1.0) (2024-03-20)
 * Translation updates

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "react-chartjs-2": "^5.2.0"
   },
   "optionalDependencies": {
-    "@folio/plugin-find-eresource": "^6.0.0"
+    "@folio/plugin-find-eresource": "^7.0.0"
   },
   "peerDependencies": {
     "@folio/stripes": "^9.0.0",


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIPER-122

This application depends on an outdated version of plugin-find-eresource (v6) that is inconsistent with that provided by the platform (v7).