### PR TITLE
Update test script to run jest with --coverage option

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,7 @@
   "scripts": {
     "lint": "eslint -f unix .",
     "qlint": "eslint -f unix  --rule '{\"no-console\":\"off\"}' .",
-    "test": "jest",
-    "coverage": "jest --coverage",
+    "test": "jest --coverage",
     "build-mod-descriptor": "stripes mod descriptor --full --strict | jq '.[]' > module-descriptor.json ",
     "start": "stripes serve --port 3005",
     "formatjs-compile": "formatjs compile-folder --ast --format simple ./translations/ui-plugin-eusage-reports ./translations/ui-plugin-eusage-reports/compiled"


### PR DESCRIPTION
New GA workflow #147 is missing coverage aritfacts.

```
[ui / Run Jest tests / Run Jest tests](https://github.com/folio-org/ui-plugin-eusage-reports/actions/runs/10826550954/job/30037752266#step:9:11)
No files were found with the provided path: artifacts/coverage-jest/. No artifacts will be uploaded.
```

This PR adjusts the 'test' script so that coverage artifacts are created and thus are included in the workflow.