### PR TITLE
UIPER-138: Migrate react-intl to v7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for ui-plugin-eusage-reports
 
+## 4.0.0 (IN PROGRESS)
+* Migrate react-intl to v7 ([UIPER-138](https://folio-org.atlassian.net/browse/UIPER-138))
+
 ## [3.2.0](https://github.com/folio-org/ui-plugin-eusage-reports/tree/v3.2.0) (2024-10-17)
 * Update plugin-find-eresource dependency. Fixes [UIPER-122](https://folio-org.atlassian.net/browse/UIPER-122).
 * Remove dependency to stripes-acq-components, use mocks local. Fixes [UIPER-123](https://folio-org.atlassian.net/browse/UIPER-123).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/plugin-eusage-reports",
-  "version": "3.2.0",
+  "version": "4.0.0",
   "description": "Stripes plugin module to View eUsage reports",
   "repository": "folio-org/ui-plugin-eusage-reports",
   "publishConfig": {
@@ -58,7 +58,7 @@
     "test": "jest --coverage",
     "build-mod-descriptor": "stripes mod descriptor --full --strict | jq '.[]' > module-descriptor.json ",
     "start": "stripes serve --port 3005",
-    "formatjs-compile": "formatjs compile-folder --ast --format simple ./translations/ui-plugin-eusage-reports ./translations/ui-plugin-eusage-reports/compiled"
+    "formatjs-compile": "stripes translate compile"
   },
   "devDependencies": {
     "@babel/core": "^7.19.3",
@@ -75,7 +75,7 @@
     "node-fetch": "^2.6.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-intl": "^6.4.4",
+    "react-intl": "^7.1.5",
     "react-router-dom": "^5.2.0"
   },
   "dependencies": {
@@ -92,7 +92,7 @@
     "@folio/stripes": "^9.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-intl": "^6.4.4",
+    "react-intl": "^7.1.5",
     "react-router-dom": "^5.2.0"
   }
 }


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIPER-138

- update react-intl to v7
- remove @formatjs/cli; stripes-cli has it built-in

Refs [STCOM-1406](https://folio-org.atlassian.net/browse/STCOM-1406)